### PR TITLE
Switch to keyword args and lists for options api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "parinfer_rust"
-version = "0.4.5"
+version = "0.4.6-beta"
 dependencies = [
  "emacs",
  "getopts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "parinfer_rust"
-version = "0.4.6-beta"
+version = "0.4.6"
 dependencies = [
  "emacs",
  "getopts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parinfer_rust"
-version = "0.4.6-beta"
+version = "0.4.6"
 authors = ["Jason Felice <jason.m.felice@gmail.com>"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parinfer_rust"
-version = "0.4.5"
+version = "0.4.6-beta"
 authors = ["Jason Felice <jason.m.felice@gmail.com>"]
 
 [lib]

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -147,16 +147,16 @@ emacs::define_errors! {
 /// Set a field within the passed options.
 ///
 /// Valid field names are:
-/// - `partial-result'
-/// - `force-balance'
-/// - `return-parens'
-/// - `comment-char'
-/// - `string-delimiters'
-/// - `lisp-vline-symbols'
-/// - `lisp-block-comments'
-/// - `guile-block-comments'
-/// - `scheme-sexp-comments'
-/// - `janet-long-strings'
+/// - `:partial-result'
+/// - `:force-balance'
+/// - `:return-parens'
+/// - `:comment-char'
+/// - `:string-delimiters'
+/// - `:lisp-vline-symbols'
+/// - `:lisp-block-comments'
+/// - `:guile-block-comments'
+/// - `:scheme-sexp-comments'
+/// - `:janet-long-strings'
 ///
 /// # Examples
 ///
@@ -169,25 +169,25 @@ fn set_option<'a>(
   new_value: Option<Value<'a>>,
 ) -> Result<()> {
   let env = option_name.env;
-  if option_name.eq(env.intern("partial-result")?) {
+  if option_name.eq(env.intern(":partial-result")?) {
     options.partial_result = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("force-balance")?) {
+  if option_name.eq(env.intern(":force-balance")?) {
     options.force_balance = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("return-parens")?) {
+  if option_name.eq(env.intern(":return-parens")?) {
     options.return_parens = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("comment-char")?) {
+  if option_name.eq(env.intern(":comment-char")?) {
     options.comment_char = new_value
       .map(|val| String::from_lisp(val))
       .transpose()?
@@ -196,7 +196,7 @@ fn set_option<'a>(
       .unwrap_or_else(Options::default_comment);
     return Ok(());
   }
-  if option_name.eq(env.intern("string-delimiters")?) {
+  if option_name.eq(env.intern(":string-delimiters")?) {
     if let Some(new_value) = new_value {
       let vector = Vector::from_lisp(new_value)?;
       let rust_values = vector
@@ -209,31 +209,31 @@ fn set_option<'a>(
     }
     return Ok(());
   }
-  if option_name.eq(env.intern("lisp-vline-symbols")?) {
+  if option_name.eq(env.intern(":lisp-vline-symbols")?) {
     options.lisp_vline_symbols = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("lisp-block-comments")?) {
+  if option_name.eq(env.intern(":lisp-block-comments")?) {
     options.lisp_block_comments = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("guile-block-comments")?) {
+  if option_name.eq(env.intern(":guile-block-comments")?) {
     options.guile_block_comments = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("scheme-sexp-comments")?) {
+  if option_name.eq(env.intern(":scheme-sexp-comments")?) {
     options.scheme_sexp_comments = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
     return Ok(());
   }
-  if option_name.eq(env.intern("janet-long-strings")?) {
+  if option_name.eq(env.intern(":janet-long-strings")?) {
     options.janet_long_strings = new_value
       .map(|val| val.is_not_nil())
       .unwrap_or_else(Options::default_false);
@@ -267,35 +267,35 @@ fn get_option<'a>(options: &Options, option_name: Value<'a>) -> Result<Value<'a>
   // The function is returning a type-erased Value because it can either be a boolean
   // or a list
   let env = option_name.env;
-  if option_name.eq(env.intern("partial-result")?) {
+  if option_name.eq(env.intern(":partial-result")?) {
     return Ok(options.partial_result.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("force-balance")?) {
+  if option_name.eq(env.intern(":force-balance")?) {
     return Ok(options.force_balance.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("return-parens")?) {
+  if option_name.eq(env.intern(":return-parens")?) {
     return Ok(options.return_parens.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("comment-char")?) {
+  if option_name.eq(env.intern(":comment-char")?) {
     return Ok(options.comment_char.to_string().into_lisp(env)?);
   }
-  if option_name.eq(env.intern("string-delimiters")?) {
+  if option_name.eq(env.intern(":string-delimiters")?) {
     // return Ok(to_lisp_vec(env, options.string_delimiters.clone())?);
     return Ok(VecToVector(options.string_delimiters.clone()).into_lisp(env)?);
   }
-  if option_name.eq(env.intern("lisp-vline-symbols")?) {
+  if option_name.eq(env.intern(":lisp-vline-symbols")?) {
     return Ok(options.lisp_vline_symbols.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("lisp-block-comments")?) {
+  if option_name.eq(env.intern(":lisp-block-comments")?) {
     return Ok(options.lisp_block_comments.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("guile-block-comments")?) {
+  if option_name.eq(env.intern(":guile-block-comments")?) {
     return Ok(options.guile_block_comments.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("scheme-sexp-comments")?) {
+  if option_name.eq(env.intern(":scheme-sexp-comments")?) {
     return Ok(options.scheme_sexp_comments.into_lisp(env)?);
   }
-  if option_name.eq(env.intern("janet-long-strings")?) {
+  if option_name.eq(env.intern(":janet-long-strings")?) {
     return Ok(options.janet_long_strings.into_lisp(env)?);
   }
 

--- a/src/emacs_wrapper.rs
+++ b/src/emacs_wrapper.rs
@@ -203,7 +203,7 @@ emacs::define_errors! {
 /// # Examples
 ///
 /// ```elisp,no_run
-/// (parinfer-rust-set-option options :partial-result t)
+/// (parinfer-rust-set-option options :guile-block-comments t)
 /// ```
 fn set_option<'a>(
   options: &mut Options,
@@ -279,16 +279,16 @@ fn set_option<'a>(
 /// Get a field within the passed options.
 ///
 /// Valid field names are:
-/// - `partial-result'
-/// - `force-balance'
-/// - `return-parens'
-/// - `comment-char'
-/// - `string-delimiters'
-/// - `lisp-vline-symbols'
-/// - `lisp-block-comments'
-/// - `guile-block-comments'
-/// - `scheme-sexp-comments'
-/// - `janet-long-strings'
+/// - `:partial-result'
+/// - `:force-balance'
+/// - `:return-parens'
+/// - `:comment-char'
+/// - `:string-delimiters'
+/// - `:lisp-vline-symbols'
+/// - `:lisp-block-comments'
+/// - `:guile-block-comments'
+/// - `:scheme-sexp-comments'
+/// - `:janet-long-strings'
 ///
 /// # Examples
 ///
@@ -419,12 +419,12 @@ fn make_request(mode: String, text: String, options: &mut Options) -> Result<Sha
   Ok(Rc::new(request))
 }
 
-/// Creates a Request from the given mode, current buffer text, and the set of Options
+/// Prints the Request as a rust struct
 ///
 /// # Examples
 ///
 /// ```elisp,no_run
-/// (parinfer--rust-print-request request)
+/// (parinfer-rust-print-request request)
 /// ```
 //
 #[defun(mod_in_name = false)]
@@ -574,12 +574,12 @@ impl IntoLisp<'_> for Error {
 #[defun(mod_in_name = false)]
 
 /// Gives a hashmap like interface to extracting values from the Answer type
-/// Accepted keys are 'text', 'success', 'cursor_x', 'cursor_line', and 'error'
+/// Accepted keys are :text, :success, :cursor-x, :cursor_line, and :error
 ///
 /// # Examples
 ///
 /// ```elisp,no_run
-/// (parinfer-rust-get-answer answer "success")
+/// (parinfer-rust-get-answer answer :text)
 /// ```
 fn get_answer<'a>(env: &'a Env, answer: &WrappedAnswer, key: AnswerKey) -> Result<Value<'a>> {
   let unwrapped_answer = answer.inner();
@@ -650,21 +650,6 @@ fn debug(
     }
   };
   Ok(())
-}
-
-////////////////////////////////
-// Error
-////////////////////////////////
-#[defun(mod_in_name = false)]
-/// Returns a string representation of an Error
-///
-/// # Examples
-///
-/// ```elisp,no_run
-/// (parinfer-rust-print-error error)
-/// ```
-fn print_error(error: &Error) -> Result<String> {
-  Ok(format!("{:?}", error).to_string())
 }
 
 #[defun(mod_in_name = false)]


### PR DESCRIPTION
This allows us to use keyword args and lists when defining options, which I find more pleasing to read and write over vectors and symbols
```
(defvar parinfer-rust--default-options '(:force-balance nil
                                         :return-parens nil
                                         :partial-result nil
                                         :lisp-vline-symbols nil
                                         :lisp-block-comments nil
                                         :guile-block-comments nil
                                         :scheme-sexp-comments nil
                                         :janet-long-strings nil
                                         :comment-char ";"
                                         :string-delimiters ("\""))
```                                         